### PR TITLE
Allow plus characters in email addresses.

### DIFF
--- a/admin/admin_config_db_test.php
+++ b/admin/admin_config_db_test.php
@@ -33,7 +33,7 @@ include ($CSS_PREFIX . 'inc/inc_head_html.php');
 function email_check ($sEmail, $sSetting) {
 	if ($sEmail == '')
 		echo "<span class = 'sans-warn'>$sSetting is not set</span><br>";
-	elseif (!eregi ("^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]*)$", $sEmail))
+	elseif (!eregi ("^[_a-z0-9-]+([.+][_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]*)$", $sEmail))
 		echo "<span class = 'sans-warn'>$sSetting: " . htmlentities ($sEmail) . " is not a valid e-mail address</span><br>\n";
 	else
 		echo "$sSetting: $sEmail<br>";

--- a/admin/admin_edit_ooc.php
+++ b/admin/admin_edit_ooc.php
@@ -40,7 +40,7 @@ if ($_POST ['btnSubmit'] != '' && CheckReferrer ('admin_edit_ooc.php')) {
 	$sEmail = SafeEmail ($_POST ['txtEmail']);
 	//Only check for valid e-mail address if one was included - user may not have an e-mail address
 	if ($sEmail != '')
-		if (!eregi ("^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]*)$", $sEmail))
+		if (!eregi ("^[_a-z0-9-]+([.+][_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]*)$", $sEmail))
 			$sWarn .= htmlentities ($sEmail) . " is not a valid e-mail address<br>\n";
 
 	if ($sWarn != '')

--- a/install/config_file_test.php
+++ b/install/config_file_test.php
@@ -32,7 +32,7 @@ include ($CSS_PREFIX . 'inc/inc_head_html.php');
 function email_check ($sEmail, $sSetting) {
 	if ($sEmail == '')
 		echo "<span class = 'sans-warn'>$sSetting is not set</span><br>";
-	elseif (!eregi ("^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]*)$", $sEmail))
+	elseif (!eregi ("^[_a-z0-9-]+([.+][_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]*)$", $sEmail))
 		echo "<span class = 'sans-warn'>$sSetting: " . htmlentities ($sEmail) . " is not a valid e-mail address</span><br>\n";
 	else
 		echo "$sSetting: $sEmail<br>";

--- a/register.php
+++ b/register.php
@@ -34,7 +34,7 @@ if ($_POST ['btnSubmit'] != '' && CheckReferrer ('register.php')) {
 	$sProblem = '';
 	$sEmail = SafeEmail ($_POST ['txtEmail']);
 	//Check e-mail address is reasonable
-	if (!eregi ("^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]*)$", $sEmail))
+	if (!eregi ("^[_a-z0-9-]+([.+][_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]*)$", $sEmail))
 		$sProblem .= htmlentities ($sEmail) . " is not a valid e-mail address<br>\n";
 	//Generate password
 	$sNewPass = '';


### PR DESCRIPTION
Email addresses with a plus in are valid but disallowed by bitsand. A good example is gmail allowing you to add any suffix to your email after a plus and it arriving in your inbox, so in my local dev bitsand I have

my user jfharden
and some test users like jfharden+staff jfharden+monster

This change allows plus characters to appear in the middle of email addresses (not at the start).
