### PR TITLE
Updated the default DB_TYPE from mysql to mysqli

### DIFF
--- a/inc/inc_config_dist.php
+++ b/inc/inc_config_dist.php
@@ -29,8 +29,10 @@ define ('ROOT_USER_ID', NULL);
 // Prefix for player ID. Player ID will be this prefix followed by a number
 define ('PID_PREFIX', '');
 
-// Type of database. Valid values are 'mysql' (for the PHP MySQL extension) or 'mysqli' (for the PHP Improved MySQL extension)
-define ('DB_TYPE','mysql');
+// Type of database. Valid values are:
+//   'mysql' (for the PHP MySQL extension, which is now deprecated as of php 5.5)
+//   'mysqli' (for the PHP Improved MySQL extension)
+define ('DB_TYPE','mysqli');
 // MySQL hostname
 define ('DB_HOST','localhost');
 // Name of MySQL database


### PR DESCRIPTION
I think changing the default db type from mysql to mysqli makes sense since the old mysql interface has been deprecated in 5.5 and you're targeting 5.5 minimum for bitsand 9. (It also means I stopped getting error logs about the deprecation)
