### PR TITLE
Bump version to 8.5

### DIFF
--- a/inc/version.php
+++ b/inc/version.php
@@ -28,7 +28,7 @@
  * Holds the current version of Bitsand
  * @const string
  */
-define('BITSAND_VERSION', '8.4');
+define('BITSAND_VERSION', '8.5');
 
 class BitsandVersion {
 	/**


### PR DESCRIPTION
8.5 was released on github but the version file wasn't bumped, this means admins get a warning all the time saying to update to 8.5 (although I am running the latest already)