### PR TITLE
Improve https detection

### DIFF
--- a/inc/inc_common.php
+++ b/inc/inc_common.php
@@ -33,7 +33,7 @@ function isHttpsScheme() {
 	}
 
 	// nginx with php-fpm sets _SERVER['HTTPS'] to 'off' when an http connection is used
-  if ($_SERVER['HTTPS'] != 'off') {
+	if ($_SERVER['HTTPS'] != 'off') {
 		return true;
 	}
 

--- a/inc/inc_common.php
+++ b/inc/inc_common.php
@@ -41,7 +41,7 @@ function isHttpsScheme() {
 }
 
 function url_scheme() {
-	return isHttpsScheme ? "https" : "http";
+	return isHttpsScheme() ? "https" : "http";
 }
 
 ?>

--- a/inc/inc_common.php
+++ b/inc/inc_common.php
@@ -31,7 +31,7 @@ function isHttpsScheme() {
 	if (empty($_SERVER['HTTPS'])) {
 		return false;
 	}
-	
+
 	// nginx with php-fpm sets _SERVER['HTTPS'] to 'off' when an http connection is used
   if ($_SERVER['HTTPS'] != 'off') {
 		return true;

--- a/inc/inc_common.php
+++ b/inc/inc_common.php
@@ -1,0 +1,47 @@
+<?php
+/*-----------------------------------------------------------------------------
+ | Bitsand - an online booking system for Live Role Play events
+ |
+ | File inc/inc_head_html.php
+ |     Author: Jonathan Harden
+ |  Copyright: (C) 2006 - 2018 The Bitsand Project
+ |             (http://github.com/PeteAUK/bitsand)
+ |
+ | Bitsand is free software; you can redistribute it and/or modify it under the
+ | terms of the GNU General Public License as published by the Free Software
+ | Foundation, either version 3 of the License, or (at your option) any later
+ | version.
+ |
+ | Bitsand is distributed in the hope that it will be useful, but WITHOUT ANY
+ | WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ | FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ | details.
+ |
+ | You should have received a copy of the GNU General Public License along with
+ | Bitsand.  If not, see <http://www.gnu.org/licenses/>.
+ +---------------------------------------------------------------------------*/
+
+function isHttpsScheme() {
+	// If HTTPS connection was terminated on a load balancer and forwarded onto an HTTP host
+	if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+		return true;
+	}
+
+	// If _SERVER['HTTPS'] hasn't been set then it's definitely an HTTP connection
+	if (empty($_SERVER['HTTPS'])) {
+		return false;
+	}
+	
+	// nginx with php-fpm sets _SERVER['HTTPS'] to 'off' when an http connection is used
+  if ($_SERVER['HTTPS'] != 'off') {
+		return true;
+	}
+
+	return false;
+}
+
+function url_scheme() {
+	return isHttpsScheme ? "https" : "http";
+}
+
+?>

--- a/inc/inc_head_db.php
+++ b/inc/inc_head_db.php
@@ -20,6 +20,7 @@
  | You should have received a copy of the GNU General Public License along with
  | Bitsand.  If not, see <http://www.gnu.org/licenses/>.
  +---------------------------------------------------------------------------*/
+require_once("inc_common.php");
 
 //Initialise $CSS_PREFIX. Will be changed (in inc_admin.php) if required
 //Note that another script may have already set it to '../' - do not change it in that case
@@ -28,15 +29,9 @@ if (!isset($CSS_PREFIX) || $CSS_PREFIX != '../')
 
 //Return base URL
 function fnSystemURL () {
-	//$sProtocol (http or https) is based on what protocol was used by referrer
-	//More robust than using $_SERVER ['HTTPS']
-	$as = parse_url ($_SERVER ['HTTP_REFERER']);
-	$sProtocol = $as ['scheme'] . '://';
-	if ($sProtocol == '://')
-		$sProtocol = 'http://';
 	$sHost = $_SERVER ['HTTP_HOST'];
 	$sURI = rtrim (dirname ($_SERVER ['PHP_SELF']), '/\\');
-	return "$sProtocol$sHost$sURI/";
+	return url_scheme() . "://$sHost$sURI/";
 }
 
 /*

--- a/inc/inc_head_html.php
+++ b/inc/inc_head_html.php
@@ -53,20 +53,11 @@ function wopen(url) {
 }
 </script>
 
+<script src='//ajax.microsoft.com/ajax/jquery/jquery-1.5.1.min.js' type='text/javascript'></script>
+<script src='//ajax.aspnetcdn.com/ajax/jquery.ui/1.8.10/jquery-ui.min.js' type='text/javascript'></script>
+<link href='//ajax.aspnetcdn.com/ajax/jquery.ui/1.8.10/themes/flick/jquery-ui.css' rel='stylesheet' type='text/css' />
+
 <?php
-//Use HTTPS or HTTP link for JQuery, to avoid browser complaining that page contains non-secure items when using HTTPS
-if ($_SERVER ["HTTPS"])
-{
-	echo "<script src='https://ajax.microsoft.com/ajax/jquery/jquery-1.5.1.min.js' type='text/javascript'></script>\n";
-	echo "<script src='https://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.10/jquery-ui.min.js' type='text/javascript'></script>\n";
-	echo "<link href='https://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.10/themes/flick/jquery-ui.css' rel='stylesheet' type='text/css' />\n";
-}
-else
-{
-	echo "<script src='http://ajax.aspnetcdn.com/ajax/jQuery/jquery-1.5.1.min.js' type='text/javascript'></script>\n";
-	echo "<script src='http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.10/jquery-ui.min.js' type='text/javascript'></script>\n";
-	echo "<link href='http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.10/themes/flick/jquery-ui.css' rel='stylesheet' type='text/css' />\n";
-}
 echo "<link rel = 'shortcut icon' href = '" . SYSTEM_URL . "favicon.ico'>\n";
 echo "<link rel = 'alternate' type = 'application/rss+xml'  href = '" . SYSTEM_URL .
 	"bookings_rss.php' title = '" . TITLE . " - Booking List'>\n";

--- a/index.php
+++ b/index.php
@@ -99,16 +99,8 @@ if ($_POST ['btnSubmit'] != '') {
 			}
 			//Run query to update/insert session, then redirect to start page
 			ba_db_query ($link, $sql);
-			//Make up URL & redirect
-			//$sProtocol (http or https) is based on what protocol was used by referrer
-			//More robust than using $_SERVER ['HTTPS']
-			$sProtocol = parse_url ($_SERVER ['HTTP_REFERER'], PHP_URL_SCHEME) . '://';
-			if ($sProtocol == '://')
-				$sProtocol = 'http://';
-			$sHost = $_SERVER ['HTTP_HOST'];
-			$sURI = rtrim (dirname ($_SERVER ['PHP_SELF']), '/\\');
-			$sFile ='start.php';
-			header ("Location: $sProtocol$sHost$sURI/$sFile");		}
+
+			header ("Location: ". fnSystemURL() ."start.php");		}
 		else
 			//Problem setting cookies. Append error message
 			$sMessage .= $sErr;


### PR DESCRIPTION
The detection for whether the site is being served by https or not doesn't work when you terminate SSL connections on a load balancer or in nginx) and redirect to php running in either a php daemon or in a cluster of backend servers. (I'm terminating SSL on an application load balancer in AWS and handing over to an AWS ECS cluster running the sites in a docker container which is why I noticed).

Also when loading the ajax javascript from a CDN we don't need to determine if it's HTTPS or not, if you just prefix the urls with only // and no scheme the browser will load over the same scheme that the website was loaded over.