### PR TITLE
Disallow blank logins

### DIFF
--- a/inc/inc_head_db.php
+++ b/inc/inc_head_db.php
@@ -39,6 +39,19 @@ function fnSystemURL () {
 	return "$sProtocol$sHost$sURI/";
 }
 
+function account_has_no_email($link, $player_id) {
+	$sql = "SELECT plEmail FROM {$db_prefix}players WHERE plPlayerId = $player_id ";
+	$result = ba_db_query ($link, $sql);
+	$row = ba_db_fetch_assoc ($result);
+
+	$match = preg_match("/^\s*$/", $row["plEmail"]);
+	if ($match === FALSE || $match === 1) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
 /*
  * Ensure that the config file has been correctly created. If not gracefully
  * stop the script from executing anything else
@@ -120,6 +133,15 @@ if ($bLoginCheck !== False) {
 	if ($_COOKIE ['BA_PlayerID'] == '' || $_COOKIE ['BA_PlayerID'] == 0) {
 		//User is not logged in, and must be logged in to access this page.
 		ForceLogin ('You must be logged in to access that page');
+	}
+	elseif (account_has_no_email($link, $_COOKIE['BA_PlayerID']) === true) {
+		// The account that is attempting to be logged into has no email set
+		// This can happen where an admin has added an account/booking from a
+		// paper booking form (so the player never has a user in the booking system)
+		// but it leaves behind an account with an empty email and password
+		// This has already been fixed but there are systems that have been running
+		// for many years with accounts like this in them.
+		ForceLogin("Error logging in, cannot login to that account");
 	}
 	else {
 		//Check player ID and login time against database sessions table

--- a/index.php
+++ b/index.php
@@ -27,8 +27,32 @@ $bLoginCheck = False;
 include ('inc/inc_head_db.php');
 $sMessage = '';
 
+function is_email_or_password_empty() {
+	// Explicitly disallow logging in with a blank email address field
+	if (!array_key_exists('txtEmail', $_POST)) {
+		return "You must enter an email address to try and log in";
+	}
+
+	$match = preg_match("/^\s*$/", $_POST['txtEmail']);
+	if ($match === FALSE || $match === 1) {
+		return "You must enter an email address to try and log in";
+	}
+
+	// Explicitly disallow logging in with a blank email address field
+	if (!array_key_exists('txtPassword', $_POST)) {
+		return "You must enter a password to try and log in";
+	}
+	$match = preg_match("/^\s*$/", $_POST['txtPassword']);
+	if ($match === FALSE || $match === 1) {
+		return "You must enter a password to try and log in";
+	}
+
+	return false;
+}
+
 $db_prefix = DB_PREFIX;
-if ($_POST ['btnSubmit'] != '') {
+
+if ($_POST ['btnSubmit'] != '' && !is_email_or_password_empty()) {
 	//User is logging in
 	$sEmail = SafeEmail ($_POST ['txtEmail']);
 	//Work out which salt to use
@@ -161,6 +185,10 @@ if ($_POST ['btnSubmit'] != '') {
 	}
 }
 else {
+	if ($blank_fields_error = is_email_or_password_empty()) {
+		$sMessage = $blank_fields_error;
+	}
+
 	//User is not logging in, so reset login cookies
 	//Cookies are reset here, but values will not be available until next page load. Note that Lynx (and others?)
 	//do not seem to reset cookies when they are set null value, so we set them to zero, then set them to null

--- a/index.php
+++ b/index.php
@@ -184,11 +184,11 @@ if ($_POST ['btnSubmit'] != '' && !is_email_or_password_empty()) {
 		ba_db_query ($link, $sql) . $sql;
 	}
 }
+elseif ($_POST ['btnSubmit'] != '') {
+	// Attempt to login with no email or password
+	$sMessage = is_email_or_password_empty();
+}
 else {
-	if ($blank_fields_error = is_email_or_password_empty()) {
-		$sMessage = $blank_fields_error;
-	}
-
 	//User is not logging in, so reset login cookies
 	//Cookies are reset here, but values will not be available until next page load. Note that Lynx (and others?)
 	//do not seem to reset cookies when they are set null value, so we set them to zero, then set them to null


### PR DESCRIPTION
Some of the older booking systems have ended up with users which can be logged into with no username and password. This PR adds explicit denial of logging into accounts with no email address set, and also explicit denial of attempting to log in with no username or no password entered.