### PR TITLE
Fix merge problem that prevents login

### DIFF
--- a/inc/inc_head_db.php
+++ b/inc/inc_head_db.php
@@ -116,7 +116,7 @@ if ($bLoginCheck !== False) {
 		//User is not logged in, and must be logged in to access this page.
 		ForceLogin ('You must be logged in to access that page');
 	}
-	elseif (account_has_no_email($link, $_COOKIE['BA_PlayerID']) === true) {
+	elseif (account_has_no_email($link, $PLAYER_ID) === true) {
 		// The account that is attempting to be logged into has no email set
 		// This can happen where an admin has added an account/booking from a
 		// paper booking form (so the player never has a user in the booking system)


### PR DESCRIPTION
The merges of other PRs left behind one of the uses of COOKIE instead of the sessions, the current master version is unable to allow logins, this switches to use the player id set as part of the session setup instead of the value in the now non-existent cookie.